### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,30 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  checks:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Check riscv32i-unknown-none-elf
+      run: cargo check --verbose --target=riscv32i-unknown-none-elf
+    - name: Check riscv32imc-unknown-none-elf
+      run: cargo check --verbose --target=riscv32imc-unknown-none-elf
+    - name: Check riscv32imac-unknown-none-elf
+      run: cargo check --verbose --target=riscv32imac-unknown-none-elf
+    - name: Check riscv64imac-unknown-none-elf
+      run: cargo check --verbose --target=riscv64imac-unknown-none-elf
+    - name: Check riscv64gc-unknown-none-elf
+      run: cargo check --verbose --target=riscv64gc-unknown-none-elf
+    - name: Check riscv64gc-unknown-linux-gnu
+      run: cargo check --verbose --target=riscv64gc-unknown-linux-gnu


### PR DESCRIPTION
Runs `cargo check` for the following targets:
- `riscv32i-unknown-none-elf`
- `riscv32imc-unknown-none-elf`
- `riscv32imac-unknown-none-elf`
- `riscv64imac-unknown-none-elf`
- `riscv64gc-unknown-none-elf`
- `riscv64gc-unknown-linux-gnu`